### PR TITLE
Fixed clang completeAt

### DIFF
--- a/clang/clang_test.go
+++ b/clang/clang_test.go
@@ -36,6 +36,39 @@ func TestClang(t *testing.T) {
 	}
 }
 
+func TestClangCompleteatNotIdentifierBegin(t *testing.T) {
+	if skip {
+		t.Skipf("Clang not installed, skipping")
+	}
+	var (
+		a content.CompleteAtArgs
+		b content.CompletionResult
+		c Clang
+	)
+
+	a.Location.Column = 10
+	a.Location.Line = 5
+	a.Location.File.Name = "testdata/set.cpp"
+	a.SessionOverrides.Set("clang_language", "c++")
+	if err := c.CompleteAt(&a, &b); err != nil {
+		t.Error(err)
+	} else {
+		contain_clear := false
+		contain_printf := false
+		for _, method := range b.Methods {
+			if method.Name.Relative == "clear" {
+				contain_clear = true
+			}
+			if method.Name.Relative == "printf" {
+				contain_printf = true
+			}
+		}
+		if !contain_clear || contain_printf {
+			t.Error("Completion result contains incorrect data")
+		}
+	}
+}
+
 func TestClangUnsaved(t *testing.T) {
 	if skip {
 		t.Skipf("Clang not installed, skipping")
@@ -88,7 +121,6 @@ void main() {
 		fmt.Print("\n")
 		t.Error(d)
 	}
-
 }
 
 func TestParseResult(t *testing.T) {

--- a/clang/clang_test.go
+++ b/clang/clang_test.go
@@ -36,39 +36,6 @@ func TestClang(t *testing.T) {
 	}
 }
 
-func TestClangCompleteatNotIdentifierBegin(t *testing.T) {
-	if skip {
-		t.Skipf("Clang not installed, skipping")
-	}
-	var (
-		a content.CompleteAtArgs
-		b content.CompletionResult
-		c Clang
-	)
-
-	a.Location.Column = 10
-	a.Location.Line = 5
-	a.Location.File.Name = "testdata/set.cpp"
-	a.SessionOverrides.Set("clang_language", "c++")
-	if err := c.CompleteAt(&a, &b); err != nil {
-		t.Error(err)
-	} else {
-		contain_clear := false
-		contain_printf := false
-		for _, method := range b.Methods {
-			if method.Name.Relative == "clear" {
-				contain_clear = true
-			}
-			if method.Name.Relative == "printf" {
-				contain_printf = true
-			}
-		}
-		if !contain_clear || contain_printf {
-			t.Error("Completion result contains incorrect data")
-		}
-	}
-}
-
 func TestClangUnsaved(t *testing.T) {
 	if skip {
 		t.Skipf("Clang not installed, skipping")
@@ -116,9 +83,6 @@ void main() {
 			t.Errorf("Couldn't write test data to %s: %s", fn, err)
 		}
 	} else if d := util.Diff(expected, res); len(d) != 0 {
-		fmt.Print("res:")
-		fmt.Print(res)
-		fmt.Print("\n")
 		t.Error(d)
 	}
 }
@@ -225,15 +189,4 @@ func TestGetDefinition(t *testing.T) {
 	} else {
 		t.Log(b)
 	}
-}
-
-func TestIdentificatorBegin(t *testing.T) {
-	if getIdentificatorBegin(" ~asd", 3) != 2 { t.Error("failed example 1") }
-	if getIdentificatorBegin("   ~   asd", 8) != 7 { t.Error("failed example 2") }
-	if getIdentificatorBegin(" a:: ~ asd", 8) != 5 { t.Error("failed example 3") }
-	if getIdentificatorBegin(" a ->~as", 7) != 5 { t.Error("failed example 4") }
-	if getIdentificatorBegin("a. ~s", 4) != 3 { t.Error("failed example 5") }
-	if getIdentificatorBegin(" asdasd", 5) != 1 { t.Error("failed example 6") }
-	if getIdentificatorBegin(".", 1) != 1 { t.Error("failed example 7") }
-	if getIdentificatorBegin("a", 1) != 0 { t.Error("failed example 8") }
 }

--- a/clang/clang_test.go
+++ b/clang/clang_test.go
@@ -28,6 +28,7 @@ func TestClang(t *testing.T) {
 	a.Location.Column = 1
 	a.Location.Line = 4
 	a.Location.File.Name = "testdata/hello.cpp"
+	a.SessionOverrides.Set("clang_language", "c++")
 	if err := c.CompleteAt(&a, &b); err != nil {
 		t.Error(err)
 	} else {
@@ -62,7 +63,8 @@ void main() {
 `
 	a.Location.Line = 11
 	a.Location.Column = 4
-	a.SessionOverrides.Set("compiler_flags", []string{"-x", "c++", "-fno-exceptions"})
+	a.SessionOverrides.Set("compiler_flags", []string{"-fno-exceptions"})
+	a.SessionOverrides.Set("clang_language", "c++")
 	if err := c.CompleteAt(&a, &b); err != nil {
 		t.Error(err)
 	}
@@ -81,6 +83,9 @@ void main() {
 			t.Errorf("Couldn't write test data to %s: %s", fn, err)
 		}
 	} else if d := util.Diff(expected, res); len(d) != 0 {
+		fmt.Print("res:")
+		fmt.Print(res)
+		fmt.Print("\n")
 		t.Error(d)
 	}
 
@@ -180,6 +185,7 @@ func TestGetDefinition(t *testing.T) {
 	a.Location.Column = 2
 	a.Location.Line = 4
 	a.Location.File.Name = "testdata/hello.cpp"
+	a.SessionOverrides.Set("clang_language", "c++")
 	if err := c.GetDefinition(&a, &b); err != nil {
 		t.Error(err)
 	} else if b.File.Name == "" || b.Line == 0 || b.Column == 0 {
@@ -187,4 +193,15 @@ func TestGetDefinition(t *testing.T) {
 	} else {
 		t.Log(b)
 	}
+}
+
+func TestIdentificatorBegin(t *testing.T) {
+	if getIdentificatorBegin(" ~asd", 3) != 2 { t.Error("failed example 1") }
+	if getIdentificatorBegin("   ~   asd", 8) != 7 { t.Error("failed example 2") }
+	if getIdentificatorBegin(" a:: ~ asd", 8) != 5 { t.Error("failed example 3") }
+	if getIdentificatorBegin(" a ->~as", 7) != 5 { t.Error("failed example 4") }
+	if getIdentificatorBegin("a. ~s", 4) != 3 { t.Error("failed example 5") }
+	if getIdentificatorBegin(" asdasd", 5) != 1 { t.Error("failed example 6") }
+	if getIdentificatorBegin(".", 1) != 1 { t.Error("failed example 7") }
+	if getIdentificatorBegin("a", 1) != 0 { t.Error("failed example 8") }
 }

--- a/clang/testdata/set.cpp
+++ b/clang/testdata/set.cpp
@@ -1,6 +1,0 @@
-#include <set>
-
-int main() {
-    std::set<int> a;
-    a.inse
-}

--- a/clang/testdata/set.cpp
+++ b/clang/testdata/set.cpp
@@ -1,0 +1,6 @@
+#include <set>
+
+int main() {
+    std::set<int> a;
+    a.inse
+}

--- a/daemon.go
+++ b/daemon.go
@@ -73,6 +73,7 @@ func runRpcDaemon() error {
 		err error
 	)
 	if err = d.init(); err != nil {
+		log4go.Error(err)
 		return err
 	}
 	defer d.close()

--- a/editor/sublime/plugin.py
+++ b/editor/sublime/plugin.py
@@ -162,6 +162,7 @@ def prepare_request(view, prefix, locations, settings):
         make_proxy()
     s = time.time()
     row, col = view.rowcol(locations[0])
+    col -= len(prefix)
 
     # TODO: detecting which "driver" is to be used should at some point be possible (but not required) to delegate to the server
     drivers = {

--- a/editor/sublime/plugin.py
+++ b/editor/sublime/plugin.py
@@ -57,6 +57,7 @@ def pipe_reader(name, pipe, output=False):
 def start_daemon(daemon_command=None):
     global daemon
     global last_launch
+    log("Starting deamon")
     if daemon_command == None:
         settings = sublime.load_settings("completion.sublime-settings")
         daemon_command = settings.get("daemon_command")
@@ -90,6 +91,7 @@ def do_query(context, callback, driver, args, launch_daemon, daemon_command, deb
         s = time.time()
         try:
             response = driver.CompleteAt(args)
+            log("Got response from driver")
             break
         except jsonrpc.RPCFault as e:
             print(e.error_data)
@@ -190,6 +192,7 @@ def prepare_request(view, prefix, locations, settings):
             "compiler_flags": view.settings().get("sublimeclang_options", []),
             "net_paths":view.settings().get("net_paths", []),
             "net_assemblies":view.settings().get("net_assemblies", []),
+            "clang_language": lang   # TODO: clang needs -x argument, i couldn't figure out how to do it more pretty
         }
     }
     if view.is_dirty():


### PR DESCRIPTION
Added additional parameter to session: clang_language
  it's needed by clang to pass correct -x parameter. I think it's good idea to get language from editor
Implemented finding beginning of identifier we want to complete at
  it's needed to meet requirement of http://clang.llvm.org/doxygen/group__CINDEX__CODE__COMPLET.html#ga50fedfa85d8d1517363952f2e10aa3bf

TODO: sublime text has problems with completing destructors because it assumes that identifier must start with letter or underscore while destructors are starting with ~.