### PR TITLE
Fix the build.

### DIFF
--- a/java/class.go
+++ b/java/class.go
@@ -217,7 +217,7 @@ func (a *attribute_info) String(c *ConstantPool) (ret string) {
 	switch n := c.Lut(a.Attribute_name_index).String(); n {
 	case "Signature", "SourceFile":
 		ret += "="
-		br := binary.BinaryReader{bytes.NewReader(a.Info), binary.BigEndian}
+		br := binary.BinaryReader{Reader: bytes.NewReader(a.Info), Endianess: binary.BigEndian}
 		if i16, err := br.Uint16(); err != nil {
 			ret += err.Error()
 		} else {
@@ -226,7 +226,7 @@ func (a *attribute_info) String(c *ConstantPool) (ret string) {
 	case "Code":
 		ret += " ( "
 		var cl Code_attribute
-		br := binary.BinaryReader{bytes.NewReader(a.Info), binary.BigEndian}
+		br := binary.BinaryReader{Reader: bytes.NewReader(a.Info), Endianess: binary.BigEndian}
 		if err := br.ReadInterface(&cl); err != nil {
 			ret += err.Error()
 		} else {
@@ -319,7 +319,7 @@ const (
 )
 
 func NewClass(reader io.ReadSeeker) (*Class, error) {
-	r := binary.BinaryReader{reader, binary.BigEndian}
+	r := binary.BinaryReader{Reader: reader, Endianess: binary.BigEndian}
 	var c Class
 	if err := r.ReadInterface(&c); err != nil {
 		return nil, err

--- a/java/class_all_test.go
+++ b/java/class_all_test.go
@@ -25,7 +25,7 @@ func testparse(c *Class, members []member_info, method bool, t *testing.T) {
 		var p2 signatures.SIGNATURES
 		for _, attr := range members[i].Attributes {
 			if c.Constant_pool.Lut(attr.Attribute_name_index).String() == "Signature" {
-				br := binary.BinaryReader{bytes.NewReader(attr.Info), binary.BigEndian}
+				br := binary.BinaryReader{Reader: bytes.NewReader(attr.Info), Endianess: binary.BigEndian}
 				if i16, err := br.Uint16(); err != nil {
 					t.Error(err)
 				} else {

--- a/net/assembly.go
+++ b/net/assembly.go
@@ -80,7 +80,7 @@ func (a *Assembly) Complete(t *content.Type) (*content.CompletionResult, error) 
 func LoadAssembly(r io.ReadSeeker) (*Assembly, error) {
 
 	var (
-		br        = binary.BinaryReader{r, binary.LittleEndian}
+		br        = binary.BinaryReader{Reader: r, Endianess: binary.LittleEndian}
 		err       error
 		pe_offset uint32
 		coff      coff_file_header


### PR DESCRIPTION
BinaryReader now has a private member field, and
thus when constructing we need to pass keys.