### PR TITLE
Added escape characters to rpc path for OS X.

### DIFF
--- a/editor/sublime/sublime.go
+++ b/editor/sublime/sublime.go
@@ -64,8 +64,8 @@ func (s *Sublime) Install() error {
 	}
 	switch runtime.GOOS {
 	case "darwin":
-		st_paths = append(st_paths, filepath.Join(u.HomeDir, "Library", "Application Support", "Sublime Text 2", "Packages"))
-		st_paths = append(st_paths, filepath.Join(u.HomeDir, "Library", "Application Support", "Sublime Text 3", "Packages"))
+		st_paths = append(st_paths, filepath.Join(u.HomeDir, "Library", "Application\\ Support", "Sublime\\ Text\\ 2", "Packages"))
+		st_paths = append(st_paths, filepath.Join(u.HomeDir, "Library", "Application\\ Support", "Sublime\\ Text\\ 3", "Packages"))
 	case "linux":
 		st_paths = append(st_paths, filepath.Join(u.HomeDir, ".config", "sublime-text-2", "Packages"))
 		st_paths = append(st_paths, filepath.Join(u.HomeDir, ".config", "sublime-text-3", "Packages"))


### PR DESCRIPTION
Without escaping the space characters, the RPC daemon will not launch and crashes.
Escaping with '\\' is required as sublime -settings files will not accept the unescaped '\' version.