### PR TITLE
Fix executable name

### DIFF
--- a/build/Makefile
+++ b/build/Makefile
@@ -34,7 +34,7 @@ all: ../../parser $(PEGS) ../editor/archive_data.go completion
 	go run archive.go ${ARCHIVE_DATA}
 
 completion: $(GENERATED)
-	go build -o completion ../
+	go build ../
 
 test: completion
 	go test -tags=nolibclang github.com/quarnster/completion/...


### PR DESCRIPTION
Previously on Windows, the executable was called "completion". Windows
does not play well with executables without a ".exe" extension. A
simple "go build" is a better choice because it will always choose the
correct name and extension for each platform.